### PR TITLE
Remove unneeded `--save`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains a number of detailed examples demonstrating how to use:
 ```
 git clone https://github.com/ldthomas/apg-js2-examples.git examples
 cd examples 
-npm install --save
+npm install
 ```
 **APG Examples:**  
 In the package.json are the scripts:


### PR DESCRIPTION
This is extremely minor, but `--save` is only useful if adding modules (so it'll update package.json). When installing predefined dependencies with `npm install`, it's not doing anything.